### PR TITLE
Add converter tool tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ static-checks: vendor
 SOURCE_DIR?=$(dir $(lastword $(MAKEFILE_LIST)))
 SOURCE_DIR:=$(abspath $(SOURCE_DIR))
 LOCAL_IP_ENV?=$(shell ip route get 8.8.8.8 | head -1 | awk '{print $$7}')
-ST_TO_RUN?=tests/st/calicoctl/test_crud.py
+ST_TO_RUN?=tests/st/calicoctl/
 # Can exclude the slower tests with "-a '!slow'"
 ST_OPTIONS?=
 
@@ -189,6 +189,7 @@ st: dist/calicoctl run-etcd-host
 	           -e MY_IP=$(LOCAL_IP_ENV) \
 	           --rm -t \
 	           -v $(SOURCE_DIR):/code \
+	           -v /var/run/docker.sock:/var/run/docker.sock \
 	           calico/test$(ARCHTAG) \
 	           sh -c 'nosetests $(ST_TO_RUN) -sv --nologcapture  --with-xunit --xunit-file="/code/nosetests.xml" --with-timer $(ST_OPTIONS)'
 

--- a/calicoctl/resourcemgr/workloadendpoint.go
+++ b/calicoctl/resourcemgr/workloadendpoint.go
@@ -28,15 +28,15 @@ func init() {
 		api.NewWorkloadEndpointList(),
 		true,
 		[]string{"workloadendpoint", "workloadendpoints", "wep", "weps"},
-		[]string{"NAME", "NODE", "WORKLOAD", "INTERFACE"},
-		[]string{"NAME", "NODE", "WORKLOAD", "NETWORKS", "INTERFACE", "PROFILES", "NATS"},
+		[]string{"WORKLOAD", "NODE", "NETWORKS", "INTERFACE"},
+		[]string{"NAME", "WORKLOAD", "NODE", "NETWORKS", "INTERFACE", "PROFILES", "NATS"},
 		// NAMESPACE may be prepended in GrabTableTemplate so needs to remain in the map below
 		map[string]string{
 			"NAME":         "{{.ObjectMeta.Name}}",
 			"NAMESPACE":    "{{.ObjectMeta.Namespace}}",
 			"NODE":         "{{.Spec.Node}}",
 			"ORCHESTRATOR": "{{.Spec.Orchestrator}}",
-			"WORKLOAD":     "{{.Spec.Workload}}",
+			"WORKLOAD":     "{{if .Spec.Workload}}{{.Spec.Workload}}{{else}}{{.Spec.Pod}}{{end}}",
 			"NETWORKS":     "{{join .Spec.IPNetworks \",\"}}",
 			"NATS":         "{{join .Spec.IPNATs \",\"}}",
 			"PROFILES":     "{{join .Spec.Profiles \",\"}}",

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: bf679ef506400603ff7f79cd5fa2d450a52459a9bc12987a7fe3859caf9e4b73
-updated: 2017-12-08T11:31:56.38292149-08:00
+hash: fab2ac9f10cc19500c9dfdfb8042bea768647f22fa5186c2eca573de7f0f987f
+updated: 2017-12-12T10:11:19.612907669-06:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -213,7 +213,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 7fdfaa3a86b1f6de47000ae4772b87e8979cde6f
+  version: 0dd1677894b40aba3232f81187963e3f6875c156
   subpackages:
   - lib/apiconfig
   - lib/apis/v1
@@ -389,7 +389,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/api
-  version: 9b9dca205a15b6ce9ef10091f05d60a13fdcf418
+  version: 4df58c811fe2e65feb879227b2b245e4dc26e7ad
   subpackages:
   - admissionregistration/v1alpha1
   - apps/v1beta1
@@ -416,7 +416,7 @@ imports:
   - storage/v1
   - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: 5134afd2c0c91158afac0d8a28bd2177185a3bcc
+  version: 019ae5ada31de202164b118aee88ee2d14075c31
   subpackages:
   - pkg/api/equality
   - pkg/api/errors

--- a/glide.yaml
+++ b/glide.yaml
@@ -28,7 +28,7 @@ import:
   - ssh/terminal
 - package: github.com/projectcalico/go-yaml-wrapper
 - package: github.com/projectcalico/libcalico-go
-  version: 7fdfaa3a86b1f6de47000ae4772b87e8979cde6f
+  version: 0dd1677894b40aba3232f81187963e3f6875c156
   subpackages:
   - lib/apis/v3
   - lib/clientv3

--- a/test-data/v1/migration/README.md
+++ b/test-data/v1/migration/README.md
@@ -1,0 +1,2 @@
+The test data here is to be used when testing out the offline migration from
+v1 to v3.

--- a/test-data/v1/migration/bgppeer.yaml
+++ b/test-data/v1/migration/bgppeer.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: bgpPeer
+metadata:
+  scope: node
+  node: rack1-host1
+  peerIP: 192.168.1.1
+spec:
+  asNumber: 63400

--- a/test-data/v1/migration/hostendpoint.yaml
+++ b/test-data/v1/migration/hostendpoint.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: hostEndpoint
+metadata:
+  name: eth0
+  node: myhost
+  labels:
+    type: production
+spec:
+  interfaceName: eth0
+  expectedIPs:
+  - 192.168.0.1
+  - 192.168.0.2
+  profiles:
+  - profile1
+  - profile2

--- a/test-data/v1/migration/ippool.yaml
+++ b/test-data/v1/migration/ippool.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ipPool
+metadata:
+  cidr: 10.1.0.0/16
+spec:
+  ipip:
+    enabled: true
+    mode: cross-subnet
+  nat-outgoing: true
+  disabled: false

--- a/test-data/v1/migration/node.yaml
+++ b/test-data/v1/migration/node.yaml
@@ -1,0 +1,10 @@
+## This won't work with KDD
+apiVersion: v1
+kind: node
+metadata:
+  name: node-hostname
+spec:
+  bgp:
+    asNumber: 64512
+    ipv4Address: 10.244.0.1/24
+    ipv6Address: 2001:db8:85a3::8a2e:370:7334/120

--- a/test-data/v1/migration/policy.yaml
+++ b/test-data/v1/migration/policy.yaml
@@ -1,0 +1,77 @@
+## This won't work with KDD
+apiVersion: v1
+kind: policy
+metadata:
+  name: allow-tcp-6379
+  annotations:
+    aname: avalue
+spec:
+  order: 1234
+  selector: role == 'database' && !has(demo)
+  types:
+  - ingress
+  - egress
+  ingress:
+  - action: allow
+    protocol: tcp
+    notProtocol: udplite
+    source:
+      selector: role == 'frontend' && thing not in {'three', 'four'}
+      notSelector: role != 'something' && thing in {'one', 'two'}
+    destination:
+      ports:
+      - 6379
+  - action: allow
+    protocol: tcp
+    source:
+      notSelector: role != 'something' && thing in {'one', 'two'}
+  - action: deny
+    protocol: tcp
+    destination:
+      ports:
+      - 22
+      - 443
+      notPorts:
+      - 80
+  - action: allow
+    source:
+      nets:
+      - "172.18.18.200/32"
+      - "172.18.19.0/24"
+  - action: allow
+    source:
+      net: "172.18.18.100/32"
+  - action: deny
+    source:
+      notNet: "172.19.19.100/32"
+  - action: deny
+    source:
+      notNets:
+      - "172.18.0.0/16"
+  egress:
+  - action: allow
+    protocol: icmp
+    icmp:
+      type: 25
+      code: 25
+
+---
+apiVersion: v1
+kind: policy
+metadata:
+  name: allow-tcp-555-donottrack
+spec:
+  order: 1230
+  selector: role == 'database'
+  types:
+  - ingress
+  ingress:
+  - action: allow
+    protocol: tcp
+    source:
+      selector: role == 'cache'
+    destination:
+      ports:
+      - 555
+  doNotTrack: true
+  preDNAT: false

--- a/test-data/v1/migration/profile.yaml
+++ b/test-data/v1/migration/profile.yaml
@@ -1,0 +1,58 @@
+## This won't work with KDD
+apiVersion: v1
+kind: profile
+metadata:
+  name: profile1
+  labels:
+    profile: profile1 
+  tags:
+  - atag
+  - btag
+spec:
+  ingress:
+  - action: deny
+    protocol: udp
+    source:
+      tag: ctag
+      notTag: dtag
+      net: 172.20.0.0/16
+      notNet: 172.20.5.0/24
+    destination:
+      tag: atag
+      notPorts:
+      - 22
+      - 443
+      - 21
+      - 8080
+  - action: deny
+    protocol: tcp
+    source:
+      nets:
+      - 10.0.20.0/24
+      notNets:
+      - 10.0.20.64/25
+    destination:
+      tag: atag
+      notPorts:
+      - 22
+      - 443
+      - 21
+      - 8080
+  - action: allow
+    protocol: tcp
+    source:
+      selector: profile != 'profile1' && has(role)
+      ports:
+      - 1234
+      - 4567
+      - 8:9
+  egress:
+  - action: allow
+    destination:
+      notSelector: profile == 'system'
+  - action: allow
+    source:
+      selector: something in {'a', 'b'}
+  - action: allow
+    destination:
+      selector: something not in {'a', 'b'}

--- a/test-data/v1/migration/workloadendpoint.yaml
+++ b/test-data/v1/migration/workloadendpoint.yaml
@@ -1,0 +1,18 @@
+## This won't work with KDD
+apiVersion: v1
+kind: workloadEndpoint
+metadata:
+  name: eth0
+  workload: default.frontend-5gs43
+  orchestrator: k8s
+  node: rack1-host1
+  labels:
+    app: frontend
+    calico/k8s_ns: default
+spec:
+  interfaceName: cali0ef24ba
+  mac: ca:fe:1d:52:bb:e9
+  ipNetworks:
+  - 192.168.0.0/32
+  profiles:
+  - profile1

--- a/tests/st/calicoctl/test_crud.py
+++ b/tests/st/calicoctl/test_crud.py
@@ -706,29 +706,26 @@ class TestCalicoctlCommands(TestBase):
         rc = calicoctl("delete networkpolicy %s" % name(rev3))
         rc.assert_no_error()
 
-        def test_get(self):
-            """
-            Test that we disallow CRUD on a knp.default prefixed NetworkPolicy.
-            """
-            k8s_np = copy.deepcopy(networkpolicy_name1_rev1)
-            k8s_np['metadata']['name'] = 'knp.default.foobarfizz'
+    def test_disallow_crud_on_knp_defaults(self):
+        """
+        Test that we disallow CRUD on a knp.default prefixed NetworkPolicy.
+        """
+        k8s_np = copy.deepcopy(networkpolicy_name1_rev1)
+        k8s_np['metadata']['name'] = 'knp.default.foobarfizz'
 
-            rc = calicoctl("create", data=k8s_np)
-            rc.assert_error(text=NOT_SUPPORTED)
-            rc.assert_error(text=KUBERNETES_NP)
+        rc = calicoctl("create", data=k8s_np)
+        rc.assert_error(text=NOT_SUPPORTED)
+        rc.assert_error(text=KUBERNETES_NP)
 
-            rc = calicoctl("apply", data=k8s_np)
-            rc.assert_error(text=NOT_SUPPORTED)
-            rc.assert_error(text=KUBERNETES_NP)
+        rc = calicoctl("apply", data=k8s_np)
+        rc.assert_error(text=NOT_FOUND)
 
-            rc = calicoctl("replace", data=k8s_np)
-            rc.assert_error(text=NOT_SUPPORTED)
-            rc.assert_error(text=KUBERNETES_NP)
+        rc = calicoctl("replace", data=k8s_np)
+        rc.assert_error(text=NOT_FOUND)
 
-            rc = calicoctl("delete", data=k8s_np)
-            rc.assert_error(text=NOT_SUPPORTED)
-            rc.assert_error(text=KUBERNETES_NP)
-
+        rc = calicoctl("delete", data=k8s_np)
+        rc.assert_error(text=NOT_SUPPORTED)
+        rc.assert_error(text=KUBERNETES_NP)
 #
 #
 # class TestCreateFromFile(TestBase):

--- a/tests/st/calicoctl/test_upgrade.py
+++ b/tests/st/calicoctl/test_upgrade.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2015-2017 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import random
+
+import yaml
+from nose_parameterized import parameterized
+
+from tests.st.utils.utils import calicoctl, \
+    name, wipe_etcd, get_ip, clean_calico_data
+from tests.st.utils.v1_data import data
+
+ETCD_SCHEME = os.environ.get("ETCD_SCHEME", "http")
+ETCD_CA = os.environ.get("ETCD_CA_CERT_FILE", "")
+ETCD_CERT = os.environ.get("ETCD_CERT_FILE", "")
+ETCD_KEY = os.environ.get("ETCD_KEY_FILE", "")
+ETCD_HOSTNAME_SSL = "etcd-authority-ssl"
+
+logging.basicConfig(level=logging.DEBUG, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+tests = [
+    ("bgppeer_long_node_name", False),
+    ("bgppeer_dotted_asn", False),
+    ("hep_bad_label", True, "a qualified name must consist of alphanumeric characters"),
+    ("hep_tame", False),
+    ("hep_mixed_ip", False),
+    ("hep_label_too_long", True, "name part must be no more than 63 characters"),
+    ("hep_long_fields", False),
+    ("hep_name_too_long", True, "name is too long by 11 bytes"),
+    ("ippool_mixed", False),
+    ("ippool_v4_small", False),
+    ("ippool_v4_large", False),
+    ("node_long_name", False),
+    ("node_tame", False),
+    ("policy_long_name", False),
+    ("policy_big", False),
+    ("policy_tame", False),
+    ("profile_big", False),
+    ("profile_tame", False),
+    ("wep_bad_workload_id", True, "field must not begin with a '-'"),
+    ("wep_lots_ips", False),
+    ("wep_similar_name", True,
+     "workload was not added through the Calico CNI plugin and cannot be converted"),
+    ("wep_similar_name_2", False),
+    ("do_not_track", False),
+    ("prednat_policy", False),
+
+    # profile_long_labels Fails validation after conversion, but error is not clear.
+    # TODO: Add some error text once new validator lands and gives this test a sane error message
+    ("profile_long_labels", True),
+]
+random.shuffle(tests)
+
+
+@parameterized(tests)
+def test_converter(testname, fail_expected, error_text=None):
+    """
+    Convert a v1 object to v3, then apply the result and read it back.
+    """
+    test_converter.__name__ = testname
+    # Let's start every test afresh
+    wipe_etcd(get_ip())
+    testdata = data[testname]
+
+    # Convert data to V3 API using the tool under test
+    rc = calicoctl("convert", data=testdata)
+    if not fail_expected:
+        logger.debug("Trying to convert manifest from V1 to V3")
+        rc.assert_no_error()
+        # Get the converted yaml and clean it up (remove fields we don't care about)
+        converted_data = clean_calico_data(yaml.safe_load(rc.output))
+        original_resource = rc
+
+        # Apply the converted data
+        rc = calicoctl("create", data=original_resource.output)
+        logger.debug("Trying to create resource using converted manifest")
+        rc.assert_no_error()
+        rc = calicoctl("get %s %s -o yaml" % (converted_data['kind'], name(converted_data)))
+
+        # Comparison here needs to be against cleaned versions of data to remove Creation Timestamp
+        logger.debug("Comparing 'get'ted output with original converted yaml")
+        cleaned_output = yaml.safe_dump(
+            clean_calico_data(
+                yaml.safe_load(rc.output),
+                extra_keys_to_remove=['projectcalico.org/orchestrator', 'namespace']
+            )
+        )
+        original_resource.assert_data(cleaned_output)
+    else:
+        rc.assert_error(error_text)

--- a/tests/st/utils/v1_data.py
+++ b/tests/st/utils/v1_data.py
@@ -1,0 +1,477 @@
+# Copyright (c) 2017 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data = {}
+data['bgppeer_long_node_name'] = {
+    'apiVersion': 'v1',
+    'kind': 'bgpPeer',
+    'metadata': {
+        'scope': 'node',
+        'node': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_Also.A.Very.LongNodeNameTryingTo-CatchOut_UpgradeCode75',
+        'peerIP': '192.168.255.255',
+    },
+    'spec': {
+        'asNumber': "4294967294",
+    },
+}
+data['bgppeer_dotted_asn'] = {
+    'apiVersion': 'v1',
+    'kind': 'bgpPeer',
+    'metadata': {
+        'scope': 'global',
+        'peerIP': '2006::2:1',
+    },
+    'spec': {
+        'asNumber': "1.10",
+    },
+}
+data['hep_tame'] = {
+    'apiVersion': 'v1',
+    'kind': 'hostEndpoint',
+    'metadata': {'labels': {'type': 'production'},
+                 'name': 'eth0',
+                 'node': 'myhost'},
+    'spec': {'expectedIPs': ['192.168.0.1', '192.168.0.2'],
+             'interfaceName': 'eth0',
+             'profiles': ['profile1', 'profile2']}
+}
+data['hep_long_fields'] = {
+    'apiVersion': 'v1',
+    'kind': 'hostEndpoint',
+    'metadata': {'labels': {
+        '8roper.evil/02.key_name.which.is-also_very.long...1234567890.p': 'frontendFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0',
+        'calico/k8s_ns': 'default',
+        'type': 'type-endFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0'},
+        'name': '.123Im_a_LongInterfaceNameTryingToCatchOutUpgradeCode75',
+        'node': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_Also.A.Very.LongNodeNameTryingTo-CatchOut_UpgradeCode75'},
+    'spec': {'expectedIPs': ['fd00:1::321'],
+             'interfaceName': 'eth0',
+             'profiles': ['profile1', 'profile2']}
+}
+data['hep_label_too_long'] = {
+    'apiVersion': 'v1',
+    'kind': 'hostEndpoint',
+    'metadata': {'labels': {
+        '8roper.evil/02.key_name.which.is-also_very.long...1234567890..proper.evil-02.key_name.which.is-also_very.long...1234567890..proper.evil-02.Key_Name.which.is-also_very.long...1234567890..proper.evil-02.key_name.which.is-also_very.long...1234567890..proper.evil-02.Key_name.which.is-also_very.long...1234567890..proper.evil-02.key_name.which.is-also_very.long...1234567890..proper.evil-02.key_Name.which.is-also_very.long...1234567890..proper.evil-02.key_name.which.is-also_very.long...1234567890..proper.evil-02.9': 'frontendFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0',
+        'calico/k8s_ns': 'default',
+        'type': 'type-endFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0'},
+        'name': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Her.Im_AlsoAVeryLongInterfaceNameTryingToCatchOutUpgradeCode75',
+        'node': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_Also.A.Very.LongNodeNameTryingTo-CatchOut_UpgradeCode75'},
+    'spec': {'expectedIPs': ['fd00:1::321'],
+             'interfaceName': 'eth0',
+             'profiles': ['profile1', 'profile2']}
+}
+data['hep_bad_label'] = {
+    'apiVersion': 'v1',
+    'kind': 'hostEndpoint',
+    'metadata': {'labels': {
+        '8roper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/Key_Name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/Key_name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/key_Name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/9': 'frontendFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0',
+        'calico/k8s_ns': 'default',
+        'type': 'type-endFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0'},
+        'name': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Her.Im_AlsoAVeryLongInterfaceNameTryingToCatchOutUpgradeCode75',
+        'node': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_Also.A.Very.LongNodeNameTryingTo-CatchOut_UpgradeCode75'},
+    'spec': {'expectedIPs': ['fd00:1::321'],
+             'interfaceName': 'eth0',
+             'profiles': ['profile1', 'profile2']}
+}
+data['hep_name_too_long'] = {
+    'apiVersion': 'v1',
+    'kind': 'hostEndpoint',
+    'metadata': {'labels': {
+        'calico/k8s_ns': 'default',
+        'type': 'type-endFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0'},
+        'name': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_AlsoAVeryLongInterfaceNameTryingToCatchOutUpgradeCode75',
+        'node': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_Also.A.Very.LongNodeNameTryingTo-CatchOut_UpgradeCode75'},
+    'spec': {'expectedIPs': ['fd00:1::321'],
+             'interfaceName': 'eth0',
+             'profiles': ['profile1', 'profile2']}
+}
+data['hep_mixed_ip'] = {
+    'apiVersion': 'v1',
+    'kind': 'hostEndpoint',
+    'metadata': {'labels': {'type': 'production'},
+                 'name': 'eth0',
+                 'node': 'myotherhost'},
+    'spec': {'expectedIPs': ['192.168.0.1',
+                             '192.168.0.2',
+                             'fd00:ca:fe:1d:52:bb:e9:80'],
+             'interfaceName': 'eth0',
+             'profiles': ['profile1', 'profile2']}
+}
+data['ippool_v4_small'] = {
+    'apiVersion': 'v1',
+    'kind': 'ipPool',
+    'metadata': {'cidr': '10.1.0.0/26'},
+    'spec': {'disabled': False,
+             'ipip': {'enabled': True, 'mode': 'cross-subnet'},
+             'nat-outgoing': True}
+}
+data['ippool_v4_large'] = {
+    'apiVersion': 'v1',
+    'kind': 'ipPool',
+    'metadata': {'cidr': '10.0.0.0/8'},
+    'spec': {'disabled': False,
+             'ipip': {'enabled': True, 'mode': 'always'},
+             'nat-outgoing': True}
+}
+data['ippool_mixed'] = {
+    'apiVersion': 'v1',
+    'kind': 'ipPool',
+    'metadata': {'cidr': '2006::/64'},
+    'spec': {'disabled': False,
+             'ipip': {'enabled': False, 'mode': 'always'},
+             'nat-outgoing': False}
+}
+data['node_long_name'] = {
+    'apiVersion': 'v1',
+    'kind': 'node',
+    'metadata': {
+        'name': '-Mary_had-A-Little___Lamb--Whose---Fleece-Was-White.As.Snow...She-Also-Had_an-Evil-NodeName_in_order_to.break.upgrade-code201600'},
+    'spec': {'bgp': {'asNumber': '7.20',
+                     'ipv4Address': '10.244.0.1/24',
+                     'ipv6Address': '2001:db8:85a3::8a2e:370:7334/120'}}
+}
+data['node_tame'] = {
+    'apiVersion': 'v1',
+    'kind': 'node',
+    'metadata': {'name': 'node-hostname'},
+    'spec': {'bgp': {'asNumber': 64512,
+                     'ipv4Address': '10.244.0.1/24',
+                     'ipv6Address': '2001:db8:85a3::8a2e:370:7334/120'}}
+}
+data['policy_tame'] = {
+    'apiVersion': 'v1',
+    'kind': 'policy',
+    'metadata': {'name': 'allow-tcp-6379'},
+    'spec': {'egress': [{'action': 'allow'}],
+             'ingress': [{'action': 'allow',
+                          'destination': {'ports': [6379]},
+                          'protocol': 'tcp',
+                          'source': {'selector': "role == 'frontend'"}}],
+             'selector': "role == 'database'",
+             'types': ['ingress', 'egress']}
+}
+data['policy_long_name'] = {
+    'apiVersion': 'v1',
+    'kind': 'policy',
+    'metadata': {
+        'name': '-Mary_had-A-Little___Lamb--Whose---Fleece-Was-White.As.Snow...She-Also-Had_an-Evil-PolicyName_in_order_to.break.upgrade-code2016'},
+    'spec': {'egress': [{'action': 'allow'}],
+             'ingress': [{'action': 'allow',
+                          'destination': {'ports': [6379]},
+                          'protocol': 'tcp',
+                          'source': {'nets': ['192.168.0.1/32']}}],
+             'selector': "role == 'database'",
+             'types': ['ingress', 'egress']}
+}
+data['profile_tame'] = {
+    'apiVersion': 'v1',
+    'kind': 'profile',
+    'metadata': {'labels': {'profile': 'profile1'}, 'name': 'profile1'},
+    'spec': {'egress': [{'action': 'allow'}],
+             'ingress': [{'action': 'deny',
+                          'source': {'nets': ['10.0.20.0/24']}},
+                         {'action': 'allow',
+                          'source': {'selector': "profile == 'profile1'"}}]}
+}
+data['profile_long_labels'] = {
+    'apiVersion': 'v1',
+    'kind': 'profile',
+    'metadata': {'labels': {
+        '8roper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/Key_Name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/Key_name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/key_Name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/9': 'frontendFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0'},
+        'name': '-Mary_had-A-Little___Lamb--Whose---Fleece-Was-White.As.Snow...She-Also-Had_an-Evil-ProfileName_in_order_to.break.upgradeprofile1'},
+    'spec': {'egress': [{'action': 'allow'}],
+             'ingress': [{'action': 'deny',
+                          'source': {'nets': ['10.0.20.0/24',
+                                              '192.168.000.000/32',
+                                              '192.168.001.255/32',
+                                              '192.168.002.254/32',
+                                              '192.168.003.253/32',
+                                              '192.168.004.252/32',
+                                              '192.168.005.251/32',
+                                              '192.168.006.250/32',
+                                              '192.168.007.249/32',
+                                              '192.168.008.248/32',
+                                              '192.168.009.247/32',
+                                              '192.168.010.246/32',
+                                              '192.168.011.245/32',
+                                              '192.168.012.244/32',
+                                              '192.168.013.243/32',
+                                              '192.168.014.242/32',
+                                              '192.168.015.241/32',
+                                              '192.168.016.240/32',
+                                              '192.168.017.239/32',
+                                              '192.168.018.238/32',
+                                              '192.168.100.000/32',
+                                              '192.168.101.255/32',
+                                              '192.168.102.254/32',
+                                              '192.168.103.253/32',
+                                              '192.168.104.252/32',
+                                              '192.168.105.251/32',
+                                              '192.168.106.250/32',
+                                              '192.168.107.249/32',
+                                              '192.168.108.248/32',
+                                              '192.168.109.247/32',
+                                              '192.168.110.246/32',
+                                              '192.168.111.245/32',
+                                              '192.168.112.244/32',
+                                              '192.168.113.243/32',
+                                              '192.168.114.242/32',
+                                              '192.168.115.241/32',
+                                              '192.168.116.240/32',
+                                              '192.168.117.239/32',
+                                              '192.168.118.238/32',
+                                              '192.168.200.000/32',
+                                              '192.168.201.255/32',
+                                              '192.168.202.254/32',
+                                              '192.168.203.253/32',
+                                              '192.168.204.252/32',
+                                              '192.168.205.251/32',
+                                              '192.168.206.250/32',
+                                              '192.168.207.249/32',
+                                              '192.168.208.248/32',
+                                              '192.168.209.247/32',
+                                              '192.168.210.246/32',
+                                              '192.168.211.245/32',
+                                              '192.168.212.244/32',
+                                              '192.168.213.243/32',
+                                              '192.168.214.242/32',
+                                              '192.168.215.241/32',
+                                              '192.168.216.240/32',
+                                              '192.168.217.239/32',
+                                              '192.168.218.238/32',
+                                              '47.0.0.0/8']}},
+                         {'action': 'allow',
+                          'source': {'selector': "profile == 'profile1'"}}]}
+}
+data['policy_big'] = {
+    'apiVersion': 'v1',
+    'kind': 'policy',
+    'metadata': {'annotations': {'aname': 'avalue'}, 'name': 'allow-tcp-6379'},
+    'spec': {'egress': [{'action': 'allow',
+                         'icmp': {'code': 25, 'type': 25},
+                         'protocol': 'icmp'}],
+             'ingress': [{'action': 'allow',
+                          'destination': {'ports': [6379]},
+                          'notProtocol': 'udplite',
+                          'protocol': 'tcp',
+                          'source': {
+                              'notSelector': "role != 'something' && thing in {'one', 'two'}",
+                              'selector': "role == 'frontend' && thing not in {'three', 'four'}"}},
+                         {'action': 'allow',
+                          'protocol': 'tcp',
+                          'source': {
+                              'notSelector': "role != 'something' && thing in {'one', 'two'}"}},
+                         {'action': 'deny',
+                          'destination': {'notPorts': [80],
+                                          'ports': [22, 443]},
+                          'protocol': 'tcp'},
+                         {'action': 'allow',
+                          'source': {'nets': ['172.18.18.200/32',
+                                              '172.18.19.0/24']}},
+                         {'action': 'allow',
+                          'source': {'net': '172.18.18.100/32'}},
+                         {'action': 'deny',
+                          'source': {'notNet': '172.19.19.100/32'}},
+                         {'action': 'deny',
+                          'source': {'notNets': ['172.18.0.0/16']}}],
+             'order': 1234,
+             'selector': "role == 'database' && !has(demo)",
+             'types': ['ingress', 'egress']}
+}
+data['profile_big'] = {
+    'apiVersion': 'v1',
+    'kind': 'profile',
+    'metadata': {'labels': {'profile': 'profile1'},
+                 'name': 'profile1',
+                 'tags': ['atag', 'btag']},
+    'spec': {'egress': [{'action': 'allow',
+                         'destination': {'notSelector': "profile == 'system'"}},
+                        {'action': 'allow',
+                         'source': {'selector': "something in {'a', 'b'}"}},
+                        {'action': 'allow',
+                         'destination': {'selector': "something not in {'a', 'b'}"}}],
+             'ingress': [{'action': 'deny',
+                          'destination': {'notPorts': [22, 443, 21, 8080],
+                                          'tag': 'atag'},
+                          'protocol': 'udp',
+                          'source': {'net': '172.20.0.0/16',
+                                     'notNet': '172.20.5.0/24',
+                                     'notTag': 'dtag',
+                                     'tag': 'ctag'}},
+                         {'action': 'deny',
+                          'destination': {'notPorts': [22, 443, 21, 8080],
+                                          'tag': 'atag'},
+                          'protocol': 'tcp',
+                          'source': {'nets': ['10.0.21.128/25'],
+                                     'notNets': ['10.0.20.0/24']}},
+                         {'action': 'deny',
+                          'protocol': 'tcp',
+                          'source': {'notNets': ['10.0.21.128/25']}},
+                         {'action': 'allow',
+                          'protocol': 'tcp',
+                          'source': {'ports': [1234, 4567, 489],
+                                     'selector': "profile != 'profile1' && has(role)"}}]}
+}
+data['wep_lots_ips'] = {
+    'apiVersion': 'v1',
+    'kind': 'workloadEndpoint',
+    'metadata': {'labels': {'app': 'frontend', 'calico/k8s_ns': 'default'},
+                 'name': 'eth0',
+                 'node': 'rack1-host1',
+                 'orchestrator': 'k8s',
+                 'workload': 'default.frontend-5gs43'},
+    'spec': {'interfaceName': 'cali0ef24ba',
+             'ipNetworks': ['192.168.000.000/32',
+                            '192.168.001.255/32',
+                            '192.168.002.254/32',
+                            '192.168.003.253/32',
+                            '192.168.004.252/32',
+                            '192.168.005.251/32',
+                            '192.168.006.250/32',
+                            '192.168.007.249/32',
+                            '192.168.008.248/32',
+                            '192.168.009.247/32',
+                            '192.168.010.246/32',
+                            '192.168.011.245/32',
+                            '192.168.012.244/32',
+                            '192.168.013.243/32',
+                            '192.168.014.242/32',
+                            '192.168.015.241/32',
+                            '192.168.016.240/32',
+                            '192.168.017.239/32',
+                            '192.168.018.238/32',
+                            '192.168.100.000/32',
+                            '192.168.101.255/32',
+                            '192.168.102.254/32',
+                            '192.168.103.253/32',
+                            '192.168.104.252/32',
+                            '192.168.105.251/32',
+                            '192.168.106.250/32',
+                            '192.168.107.249/32',
+                            '192.168.108.248/32',
+                            '192.168.109.247/32',
+                            '192.168.110.246/32',
+                            '192.168.111.245/32',
+                            '192.168.112.244/32',
+                            '192.168.113.243/32',
+                            '192.168.114.242/32',
+                            '192.168.115.241/32',
+                            '192.168.116.240/32',
+                            '192.168.117.239/32',
+                            '192.168.118.238/32',
+                            '192.168.200.000/32',
+                            '192.168.201.255/32',
+                            '192.168.202.254/32',
+                            '192.168.203.253/32',
+                            '192.168.204.252/32',
+                            '192.168.205.251/32',
+                            '192.168.206.250/32',
+                            '192.168.207.249/32',
+                            '192.168.208.248/32',
+                            '192.168.209.247/32',
+                            '192.168.210.246/32',
+                            '192.168.211.245/32',
+                            '192.168.212.244/32',
+                            '192.168.213.243/32',
+                            '192.168.214.242/32',
+                            '192.168.215.241/32',
+                            '192.168.216.240/32',
+                            '192.168.217.239/32',
+                            '192.168.218.238/32'],
+             'mac': 'ca:fe:1d:52:bb:e9',
+             'profiles': ['profile1']}
+}
+data['wep_similar_name'] = {
+    'apiVersion': 'v1',
+    'kind': 'workloadEndpoint',
+    'metadata': {'labels': {'app': 'frontend', 'calico/k8s_ns': 'default'},
+                 'name': 'eth0',
+                 'node': 'rack1-host1',
+                 'orchestrator': 'k8s',
+                 'workload': 'default/frontend-5gs43'},
+    'spec': {'interfaceName': 'cali0ef24ba',
+             'ipNetworks': ['192.168.0.0/32',
+                            '192.168.1.255/32',
+                            '192.168.2.254/32',
+                            '192.168.3.253/32',
+                            '192.168.4.252/32',
+                            '192.168.5.251/32',
+                            '192.168.6.250/32',
+                            '192.168.7.249/32',
+                            '192.168.8.248/32',
+                            '192.168.9.247/32',
+                            '192.168.10.246/32',
+                            '192.168.11.245/32',
+                            '192.168.12.244/32',
+                            '192.168.13.243/32',
+                            '192.168.14.242/32',
+                            '192.168.15.241/32',
+                            '192.168.16.240/32',
+                            '192.168.17.239/32',
+                            '192.168.18.238/32'],
+             'mac': 'fe:ed:ca:fe:00:00',
+             'profiles': ['profile1']}
+}
+data['wep_bad_workload_id'] = {
+    'apiVersion': 'v1',
+    'kind': 'workloadEndpoint',
+    'metadata': {'labels': {
+        'calico/k8s_ns': 'default'},
+        'name': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_AlsoAVeryLongInterfaceNameTryingToCatchOutUpgradeCode75',
+        'node': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_Also.A.Very.LongNodeNameTryingTo-CatchOut_UpgradeCode75',
+        'orchestrator': 'k8s',
+        'workload': 'default.-_.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My_AlsoAVeryLongWorkload-NameTryingToCatchOutUpgradeCode5'},
+    'spec': {'interfaceName': 'cali0ef24ba',
+             'ipNetworks': ['192.168.255.255/32', 'fd::1:40'],
+             'mac': 'ca:fe:1d:52:bb:e9',
+             'profiles': ['profile1']}
+}
+data['wep_similar_name_2'] = {
+    'apiVersion': 'v1',
+    'kind': 'workloadEndpoint',
+    'metadata': {'labels': {'app': 'frontend', 'calico/k8s_ns': 'default'},
+                 'name': 'eth0',
+                 'node': 'rack1-host1',
+                 'orchestrator': 'k8s',
+                 'workload': 'default.frontend.5gs43'},
+    'spec': {'interfaceName': 'cali0ef24ba',
+             'ipNetworks': ['fd00:ca:fe:1d:52:bb:e9:80'],
+             'mac': 'ca:fe:1d:52:bb:e9',
+             'profiles': ['profile1']}
+}
+data['do_not_track'] = {
+    'apiVersion': 'v1',
+    'kind': 'policy',
+    'metadata': {'name': 'allow-tcp-555-donottrack'},
+    'spec': {'doNotTrack': True,
+             'ingress': [{'action': 'allow',
+                          'destination': {'ports': [555]},
+                          'protocol': 'tcp',
+                          'source': {'selector': "role == 'cache'"}}],
+             'order': 1230,
+             'selector': "role == 'database'",
+             'types': ['ingress']}
+}
+data['prednat_policy'] = {
+    'apiVersion': 'v1',
+    'kind': 'policy',
+    'metadata': {'name': 'allow-cluster-internal-ingress'},
+    'spec': {'ingress': [{'action': 'allow',
+                          'source': {'nets': ['10.240.0.0/16',
+                                              '192.168.0.0/16']}}],
+             'order': 10,
+             'preDNAT': True,
+             'selector': 'has(host-endpoint)'}
+}


### PR DESCRIPTION
Added some tests for you to try to get your upgrade tool to pass.  

Note that none of these tests pass at present - failures vary from:
- Creation timestamp being present in get output
   - (both bgppeer tests, hep_tame, hep_mixed_ip, ippool_v4_small, ippool_v4_large, ippool_mixed, node_long_name)
- Converted item fails to create
    - (hep_long_fields, policy_long_name, profile_long_labels)
- Fields added to new item
    - (policy_tame, profile_tame, 
- Fields removed from new item:
    - (wep_lots_ips, wep_similar_name_2)
- Panic when running converter
    - (wep_similar_name)
- Error from converter
   - (wep_long_labels)

And before you ask, yes - all test data works with calicoctl from 2.6.4.  Actually - I might see if I can find a way for the test to try that in every case too.